### PR TITLE
Add ability to specify time-to-live for a bucket

### DIFF
--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -264,18 +264,9 @@ prop_encode_decode_bucket_info() ->
             end).
 
 prop_encode_decode_ttl() ->
-    ?FORALL(Msg = {ttl, Bucket, TTL}, {ttl, bucket(), ttl()},
-            case TTL of
-                infinity ->
-                    Encoded = dproto_tcp:encode(Msg),
-                    Decoded = dproto_tcp:decode(Encoded),
-                    ?WHENFAIL(
-                       io:format(user,
-                                 "~p -> ~p -> ~p~n",
-                                 [Msg, Encoded, Decoded]),
-                       {ttl, Bucket, 0} =:= Decoded);
-                _ when is_integer(TTL), TTL >= 0,
-                       (TTL band 16#FFFFFFFFFFFFFFFF) =:= TTL ->
+    ?FORALL(Msg = {ttl, _, TTL}, {ttl, bucket(), ttl()},
+            case valid_time(TTL) of
+                true ->
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),
                     ?WHENFAIL(

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -249,10 +249,10 @@ prop_encode_decode_metrics() ->
             end).
 
 prop_encode_decode_bucket_info() ->
-    ?FORALL(Msg = {Resolution, _, _}, {resolution(), pos_int(), ttl()},
-            case valid_time(Resolution) of
+    ?FORALL(Msg = {Res, PPF, TTL}, {resolution(), pos_int(), ttl()},
+            case valid_time(Res) of
                 true ->
-                    Encoded = dproto_tcp:encode_bucket_info(Msg),
+                    Encoded = dproto_tcp:encode_bucket_info(Res, PPF, TTL),
                     Decoded = dproto_tcp:decode_bucket_info(Encoded),
                     ?WHENFAIL(
                        io:format(user,
@@ -265,7 +265,7 @@ prop_encode_decode_bucket_info() ->
 
 prop_encode_decode_ttl() ->
     ?FORALL(Msg = {ttl, _, TTL}, {ttl, bucket(), ttl()},
-            case valid_time(TTL) of
+            case TTL =:= infinity orelse valid_time(TTL) of
                 true ->
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -81,7 +81,7 @@ resolution() ->
     mtime().
 
 ttl() ->
-    oneof([mtime(), infinity]).
+    mtime().
 
 tcp_msg() ->
     oneof([
@@ -265,7 +265,7 @@ prop_encode_decode_bucket_info() ->
 
 prop_encode_decode_ttl() ->
     ?FORALL(Msg = {ttl, _, TTL}, {ttl, bucket(), ttl()},
-            case TTL =:= infinity orelse valid_time(TTL) of
+            case valid_time(TTL) of
                 true ->
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -81,7 +81,7 @@ resolution() ->
     mtime().
 
 ttl() ->
-    mtime().
+    oneof([infinity, mtime()]).
 
 tcp_msg() ->
     oneof([
@@ -264,9 +264,18 @@ prop_encode_decode_bucket_info() ->
             end).
 
 prop_encode_decode_ttl() ->
-    ?FORALL(Msg = {ttl, _, TTL}, {ttl, bucket(), ttl()},
-            case valid_time(TTL) of
-                true ->
+    ?FORALL(Msg = {ttl, Bucket, TTL}, {ttl, bucket(), ttl()},
+            case TTL of
+                infinity ->
+                    Encoded = dproto_tcp:encode(Msg),
+                    Decoded = dproto_tcp:decode(Encoded),
+                    ?WHENFAIL(
+                       io:format(user,
+                                 "~p -> ~p -> ~p~n",
+                                 [Msg, Encoded, Decoded]),
+                       {ttl, Bucket, 0} =:= Decoded);
+                _ when is_integer(TTL), TTL >= 0,
+                       (TTL band 16#FFFFFFFFFFFFFFFF) =:= TTL ->
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),
                     ?WHENFAIL(

--- a/include/dproto.hrl
+++ b/include/dproto.hrl
@@ -11,7 +11,7 @@
 -define(BUCKET_DELETE, 9).
 -define(SBATCH, 10).
 -define(LIST_PREFIX, 11).
--define(RESOLUTION, 12).
+-define(TTL, 12).
 
 %% number of bits used to encode the bucket size.
 %% => buckets can be 255 byte at most!

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -15,7 +15,7 @@
 
 -export_type([tcp_message/0, batch_message/0, stream_message/0]).
 
--type ttl() :: infinity | non_neg_integer().
+-type ttl() :: non_neg_integer().
 
 -type stream_message() ::
         incomplete |
@@ -155,6 +155,11 @@ decode_bucket_info(<<Resolution:?TIME_SIZE/?TIME_TYPE,
 encode(buckets) ->
     <<?BUCKETS>>;
 
+%% @doc
+%% Encodes the TTL for a bucket.  Note that a zero value is intrepeted to mean
+%% `infinity'.
+%%
+%% @end
 encode({ttl, Bucket, TTL}) when is_binary(Bucket), byte_size(Bucket) > 0,
                                 is_integer(TTL), TTL >= 0 ->
     <<?TTL,

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -235,9 +235,8 @@ encode({stream, Bucket, Delay, Resolution}) when
       Resolution > 0 ->
     <<?STREAM,
       Delay:?DELAY_SIZE/?SIZE_TYPE,
-      Resolution:?TIME_SIZE/?TIME_TYPE,
-      (byte_size(Bucket)):?BUCKET_SS/?SIZE_TYPE, Bucket/binary>>;
-
+      (byte_size(Bucket)):?BUCKET_SS/?SIZE_TYPE, Bucket/binary,
+      Resolution:?TIME_SIZE/?TIME_TYPE>>;
 
 encode({stream, Metric, Time, Points}) when
       is_binary(Metric), byte_size(Metric) > 0,
@@ -331,8 +330,8 @@ decode(<<?STREAM,
 
 decode(<<?STREAM,
          Delay:?DELAY_SIZE/?SIZE_TYPE,
-         Resolution:?TIME_SIZE/?TIME_TYPE,
-         _BucketSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BucketSize/binary>>) ->
+         _BucketSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BucketSize/binary,
+         Resolution:?TIME_SIZE/?TIME_TYPE>>) ->
     {stream, Bucket, Delay, Resolution}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The resolution, TTL, and PPF properties are merged into the bucket_info command, as part of:
https://github.com/dalmatinerdb/dalmatinerdb/issues/64
https://github.com/dalmatinerdb/dalmatinerdb/issues/63
https://github.com/dalmatinerdb/dalmatinerdb/issues/62

Again, have not been able to run the EQC tests locally.
