### PR TITLE
Add generic error response to tcp protocol

### DIFF
--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -91,7 +91,6 @@ bucket_info() ->
        ttl        => ttl()
      }.
 
-
 filter() ->
     oneof(
       [{'not', {'==', list(binary()), binary()}},
@@ -127,7 +126,8 @@ tcp_msg() ->
            get_events(),
            events_end,
            {events, events()},
-           {events, bucket(), events()}
+           {events, bucket(), events()},
+           {error, binary()}
           ]).
 
 valid_delay(_Delay) when is_integer(_Delay), _Delay > 0, _Delay < 256 ->

--- a/include/dproto.hrl
+++ b/include/dproto.hrl
@@ -19,6 +19,8 @@
 -define(END_EVENTS, 16).
 -define(GET_EVENTS_FILTERED, 17).
 
+-define(ERROR, 99).
+
 %% number of bits used to encode the bucket size.
 %% => buckets can be 255 byte at most!
 -define(BUCKET_SS, 8).
@@ -63,3 +65,6 @@
 
 %% The type used to encode time.
 -define(TIME_TYPE, unsigned-integer).
+
+%% The type used to encode error messages.
+-define(ERROR_SIZE, 8).

--- a/include/dproto.hrl
+++ b/include/dproto.hrl
@@ -19,7 +19,7 @@
 -define(END_EVENTS, 16).
 -define(GET_EVENTS_FILTERED, 17).
 
--define(ERROR, 99).
+-define(ERROR, 255).
 
 %% number of bits used to encode the bucket size.
 %% => buckets can be 255 byte at most!


### PR DESCRIPTION
This PR proposes a generic error response to a TCP command.  

I could not run the eqc tests due to licensing limitations.

Since the client synchronously awaits a reply in response to a command, including the original command in the error message seemed unnecessary.  I would like to know your opinion on adding a term to the error that matches the atom used in the original command, e.g:

{error, stream, <<"A bucket already exists with a different resolution">>}
vs
{error, <<"A bucket already exists with a different resolution">>}
