### PR TITLE
Encode read options as part of get message

### DIFF
--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -293,18 +293,18 @@ prop_encode_decode_get() ->
             end).
 
 prop_encode_decode_get_opts() ->
-    ?FORALL(Msg = {get, Bucket, Metric, Time, Count, _Opts},
+    ?FORALL(Msg = {get, Bucket, Metric, Time, Count, Opts},
             {get, bucket(), metric(), mtime(), count(), read_opts()},
             case valid_time(Time) andalso valid_count(Count) of
                 true ->
-                    Defaults = #{rr => default, r => default},
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),
-                    % Opts are augmented with defaults when not specified
-                    {get, _, _, _, _, Opts1} = Decoded,
-                    Opts2 = maps:to_list(
-                              maps:merge(Defaults, maps:from_list(Opts1))),
-                    Msg1 = {get, Bucket, Metric, Time, Count, Opts2},
+
+                    R = proplists:get_value(r, Opts, default),
+                    RR = proplists:get_value(rr, Opts, default),
+                    Opts1 = [{r, R}, {rr, RR}],
+                    Msg1 = {get, Bucket, Metric, Time, Count, Opts1},
+
                     ?WHENFAIL(
                        io:format(user,
                                  "~p -> ~p -> ~p~n",

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -115,10 +115,10 @@ get_events() ->
            ])).
 
 get_metrics() ->
+    Opts = [read_repair_opt(), r_opt()],
     oneof([
            {get, bucket(), metric(), mtime(), count()},
-           {get, bucket(), metric(), mtime(), count(),
-            read_repair_opt(), r_opt()}
+           {get, bucket(), metric(), mtime(), count(), Opts}
           ]).
 
 event() ->

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -120,12 +120,6 @@ get_events() ->
             {get_events, bucket(), min(S, E), max(S, E), filters()}
            ])).
 
-get_metrics() ->
-    oneof([
-           {get, bucket(), metric(), mtime(), count()},
-           {get, bucket(), metric(), mtime(), count(), read_opts()}
-          ]).
-
 event() ->
     {pos_int(), binary()}.
 
@@ -142,7 +136,6 @@ tcp_msg() ->
            {add, bucket(), pos_int(), pos_int(), non_neg_int()},
            {delete, bucket()},
            get_events(),
-           get_metrics(),
            events_end,
            {events, events()},
            {events, bucket(), events()},

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -84,10 +84,16 @@ ttl() ->
     oneof([infinity, mtime()]).
 
 read_repair_opt() ->
-    oneof([{rr, default}, {rr, on}, {rr, default}]).
+    {rr, oneof([default, on, off])}.
 
 r_opt() ->
-    oneof([{r, default}, {r, n}, {r, choose(1, 254)}]).
+    {r, oneof([default, r, choose(1, 254)])}.
+
+read_opt() ->
+    oneof([read_repair_opt(), r_opt()]).
+
+read_opts() ->
+    list(read_opt()).
 
 bucket_info() ->
     #{

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -84,10 +84,10 @@ ttl() ->
     oneof([infinity, mtime()]).
 
 read_repair_opt() ->
-    oneof([0, 1, 2]).
+    oneof([{rr, default}, {rr, on}, {rr, default}]).
 
 r_opt() ->
-    ?SUCHTHAT(I, int(), I >= 0 andalso (I band 16#FF) =:= I).
+    oneof([{r, default}, {r, n}, {r, choose(1, 254)}]).
 
 bucket_info() ->
     #{

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -87,7 +87,7 @@ read_repair_opt() ->
     {rr, oneof([default, on, off])}.
 
 r_opt() ->
-    {r, oneof([default, r, choose(1, 254)])}.
+    {r, oneof([default, n, choose(1, 254)])}.
 
 read_opt() ->
     oneof([read_repair_opt(), r_opt()]).
@@ -273,6 +273,43 @@ prop_encode_decode_batch_entry() ->
                                  "~p -> ~p -> ~p~n",
                                  [Msg, Encoded, Decoded]),
                        Msg =:= Decoded);
+                _ ->
+                    {'EXIT', _} = (catch dproto_tcp:encode(Msg))
+            end).
+prop_encode_decode_get() ->
+    ?FORALL(Msg = {get, _, _, Time, Count},
+            {get, bucket(), metric(), mtime(), count()},
+            case valid_time(Time) andalso valid_count(Count) of
+                true ->
+                    Encoded = dproto_tcp:encode(Msg),
+                    Decoded = dproto_tcp:decode(Encoded),
+                    ?WHENFAIL(
+                       io:format(user,
+                                 "~p -> ~p -> ~p~n",
+                                 [Msg, Encoded, Decoded]),
+                       Msg =:= Decoded);
+                _ ->
+                    {'EXIT', _} = (catch dproto_tcp:encode(Msg))
+            end).
+
+prop_encode_decode_get_opts() ->
+    ?FORALL(Msg = {get, Bucket, Metric, Time, Count, _Opts},
+            {get, bucket(), metric(), mtime(), count(), read_opts()},
+            case valid_time(Time) andalso valid_count(Count) of
+                true ->
+                    Defaults = #{rr => default, r => default},
+                    Encoded = dproto_tcp:encode(Msg),
+                    Decoded = dproto_tcp:decode(Encoded),
+                    % Opts are augmented with defaults when not specified
+                    {get, _, _, _, _, Opts1} = Decoded,
+                    Opts2 = maps:to_list(
+                              maps:merge(Defaults, maps:from_list(Opts1))),
+                    Msg1 = {get, Bucket, Metric, Time, Count, Opts2},
+                    ?WHENFAIL(
+                       io:format(user,
+                                 "~p -> ~p -> ~p~n",
+                                 [Msg, Encoded, Decoded]),
+                       Msg1 =:= Decoded);
                 _ ->
                     {'EXIT', _} = (catch dproto_tcp:encode(Msg))
             end).

--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -121,10 +121,9 @@ get_events() ->
            ])).
 
 get_metrics() ->
-    Opts = [read_repair_opt(), r_opt()],
     oneof([
            {get, bucket(), metric(), mtime(), count()},
-           {get, bucket(), metric(), mtime(), count(), Opts}
+           {get, bucket(), metric(), mtime(), count(), read_opts()}
           ]).
 
 event() ->

--- a/include/dproto.hrl
+++ b/include/dproto.hrl
@@ -60,6 +60,14 @@
 %% Number of bits used to encode the delay as part of the streaming protocol.
 -define(DELAY_SIZE, 8).
 
+%% Number of bits needed to control consistency parameters for read operations
+-define(GET_OPT_SIZE, 8).
+
+%% Disable, enable or use the default read repair option for a get request.
+-define(RR_OFF, 0).
+-define(RR_ON, 1).
+-define(RR_DEFAULT, 2).
+
 %% The type used to encode sizes.
 -define(SIZE_TYPE, unsigned-integer).
 

--- a/include/dproto.hrl
+++ b/include/dproto.hrl
@@ -63,10 +63,14 @@
 %% Number of bits needed to control consistency parameters for read operations
 -define(GET_OPT_SIZE, 8).
 
-%% Disable, enable or use the default read repair option for a get request.
--define(RR_OFF, 0).
--define(RR_ON, 1).
--define(RR_DEFAULT, 2).
+%% Read repair option enumeration
+-define(OPT_RR_ON, 1).
+-define(OPT_RR_OFF, 0).
+-define(OPT_RR_DEFAULT, 2).
+
+%% Read quorum(R) option enumeration
+-define(OPT_R_DEFAULT, 0).
+-define(OPT_R_N, 255).
 
 %% The type used to encode sizes.
 -define(SIZE_TYPE, unsigned-integer).

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -204,7 +204,7 @@ encode_bucket_info(#{
 %% @end
 %%--------------------------------------------------------------------
 
--spec decode_bucket_info(<<_:192,_:_*64>>) ->
+-spec decode_bucket_info(<<_:192, _:_*64>>) ->
                                 bucket_info().
 
 decode_bucket_info(<<Resolution:?TIME_SIZE/?TIME_TYPE,
@@ -388,7 +388,7 @@ encode_events(Es) ->
     true = is_binary(B),
     B.
 
--spec encode_event({pos_integer(), term()}) -> <<_:64,_:_*8>>.
+-spec encode_event({pos_integer(), term()}) -> <<_:64, _:_*8>>.
 encode_event({T, E}) when T > 0, is_integer(T) ->
     B = term_to_binary(E),
     <<T:?TIME_SIZE/?TIME_TYPE, (byte_size(B)):?DATA_SS/?SIZE_TYPE, B/binary>>.
@@ -468,7 +468,9 @@ decode(<<?EVENTS,
          Events/binary>>) ->
     {events, Bucket, decode_events(Events)};
 
-decode(<<?GET_EVENTS, _BSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BSize/binary, Start:?TIME_SIZE/?TIME_TYPE, End:?TIME_SIZE/?TIME_TYPE>>) ->
+decode(<<?GET_EVENTS, _BSize:?BUCKET_SS/?SIZE_TYPE,
+         Bucket:_BSize/binary, Start:?TIME_SIZE/?TIME_TYPE,
+         End:?TIME_SIZE/?TIME_TYPE>>) ->
     {get_events, Bucket, Start, End};
 decode(<<?GET_EVENTS_FILTERED,
          _BSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BSize/binary,

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -559,11 +559,11 @@ decode_batch(Rest) ->
 %% @end
 %%--------------------------------------------------------------------
 encode_rr(off) ->
-    {rr, ?OPT_RR_OFF};
+    ?OPT_RR_OFF;
 encode_rr(on) ->
-    {rr, ?OPT_RR_ON};
+    ?OPT_RR_ON;
 encode_rr(default) ->
-    {rr, ?OPT_RR_DEFAULT}.
+    ?OPT_RR_DEFAULT.
 
 decode_rr(?OPT_RR_OFF) ->
     {rr, off};

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -28,8 +28,8 @@
 
 -type ttl() :: pos_integer() | infinity.
 
-% Read repair option: 0 = off, 1 = on, 2 = default
--type rr_opt() :: 0 | 1 | 2.
+-type read_opts() :: [{rr, default} | {rr, off} | {rr, on} |
+                      {r, n} | {r, default} | {r, pos_integer()}].
 
 -type bucket_info() :: #{
                    resolution => pos_integer(),
@@ -84,8 +84,7 @@
          Metric :: binary(),
          Time :: pos_integer(),
          Count :: pos_integer(),
-         RR :: rr_opt(),
-         R :: non_neg_integer()} |
+         Opts :: read_opts()} |
         {stream,
          Bucket :: binary(),
          Delay :: pos_integer()} |

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -457,7 +457,7 @@ decode(<<?GET,
          _MetricSize:?METRIC_SS/?SIZE_TYPE, Metric:_MetricSize/binary,
          Time:?TIME_SIZE/?SIZE_TYPE, Count:?COUNT_SIZE/?SIZE_TYPE,
          RR:?GET_OPT_SIZE/?SIZE_TYPE, R:?GET_OPT_SIZE/?SIZE_TYPE>>) ->
-    Opts = [decode_rr(RR), decode_r(R)],
+    Opts = [decode_r(R), decode_rr(RR)],
     {get, Bucket, Metric, Time, Count, Opts};
 
 decode(<<?STREAM,


### PR DESCRIPTION
@Licenser could you give me your opinion on these changes - is there a better way to facilitate old vs new gets?
I left the setting of defaults to the client - unless you think that it should be part of the protocol and we set them here.