### PR TITLE
Always encode and decode gets with default options when not specified

### DIFF
--- a/eqc/tcp_proto_eqc.erl
+++ b/eqc/tcp_proto_eqc.erl
@@ -269,18 +269,22 @@ prop_encode_decode_batch_entry() ->
                 _ ->
                     {'EXIT', _} = (catch dproto_tcp:encode(Msg))
             end).
+
 prop_encode_decode_get() ->
-    ?FORALL(Msg = {get, _, _, Time, Count},
+    ?FORALL(Msg = {get, Bucket, Metric, Time, Count},
             {get, bucket(), metric(), mtime(), count()},
             case valid_time(Time) andalso valid_count(Count) of
                 true ->
                     Encoded = dproto_tcp:encode(Msg),
                     Decoded = dproto_tcp:decode(Encoded),
+                    InOpts = [],
+                    {get, Bucket, Metric, Time, Count, OutOpts} = Decoded,
+
                     ?WHENFAIL(
                        io:format(user,
                                  "~p -> ~p -> ~p~n",
                                  [Msg, Encoded, Decoded]),
-                       Msg =:= Decoded);
+                       compare_opts(InOpts, OutOpts));
                 _ ->
                     {'EXIT', _} = (catch dproto_tcp:encode(Msg))
             end).

--- a/src/dproto_tcp.erl
+++ b/src/dproto_tcp.erl
@@ -290,16 +290,8 @@ encode({delete, Bucket}) when is_binary(Bucket), byte_size(Bucket) > 0 ->
     <<?BUCKET_DELETE,
       (byte_size(Bucket)):?BUCKET_SS/?SIZE_TYPE, Bucket/binary>>;
 
-encode({get, Bucket, Metric, Time, Count}) when
-      is_binary(Bucket), byte_size(Bucket) > 0,
-      is_binary(Metric), byte_size(Metric) > 0,
-      is_integer(Time), Time >= 0, (Time band 16#FFFFFFFFFFFFFFFF) =:= Time,
-      %% We only want positive numbers <  32 bit
-      is_integer(Count), Count > 0, (Count band 16#FFFFFFFF) =:= Count ->
-    <<?GET,
-      (byte_size(Bucket)):?BUCKET_SS/?SIZE_TYPE, Bucket/binary,
-      (byte_size(Metric)):?METRIC_SS/?SIZE_TYPE, Metric/binary,
-      Time:?TIME_SIZE/?SIZE_TYPE, Count:?COUNT_SIZE/?SIZE_TYPE>>;
+encode({get, Bucket, Metric, Time, Count}) ->
+    encode({get, Bucket, Metric, Time, Count, []});
 
 encode({get, Bucket, Metric, Time, Count, Opts}) when
       is_binary(Bucket), byte_size(Bucket) > 0,
@@ -450,7 +442,8 @@ decode(<<?GET,
          _BucketSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BucketSize/binary,
          _MetricSize:?METRIC_SS/?SIZE_TYPE, Metric:_MetricSize/binary,
          Time:?TIME_SIZE/?SIZE_TYPE, Count:?COUNT_SIZE/?SIZE_TYPE>>) ->
-    {get, Bucket, Metric, Time, Count};
+    Opts = [{r, default}, {rr, default}],
+    {get, Bucket, Metric, Time, Count, Opts};
 
 decode(<<?GET,
          _BucketSize:?BUCKET_SS/?SIZE_TYPE, Bucket:_BucketSize/binary,


### PR DESCRIPTION
The previous changes were too conservative in trying to preserve backward compatibility - always encoding and decoding options affords cleaner code in ddb as suggested [here](https://github.com/dalmatinerdb/dalmatinerdb/pull/115/files#r103744003).